### PR TITLE
don't import react

### DIFF
--- a/packages/utils/src/tableProvider.ts
+++ b/packages/utils/src/tableProvider.ts
@@ -1,4 +1,4 @@
-import { DataFrame, ResolvablePromise, resolvablePromise } from 'hightable'
+import { DataFrame, ResolvablePromise, resolvablePromise } from 'hightable/src/dataframe.js'
 import { FileMetaData, parquetSchema } from 'hyparquet'
 import { parquetQueryWorker, parquetSortIndexWorker } from './workers/parquetWorkerClient.js'
 import type { AsyncBufferFrom } from './workers/types.d.ts'


### PR DESCRIPTION
Impact on @hyparam/utils.

From

```
dist/index.es.min.js  925.19 kB │ gzip: 284.48 kB │ map: 2,074.29 kB                        
dist/index.umd.min.js  659.19 kB │ gzip: 256.25 kB │ map: 2,015.26 kB 
```

to

```
dist/index.es.min.js  203.25 kB │ gzip: 114.30 kB │ map: 48.79 kB
dist/index.umd.min.js  200.96 kB │ gzip: 113.88 kB │ map: 48.17 kB
```

The impact on @hyparam/components:

from

```
dist/index.es.min.js  958.91 kB │ gzip: 293.95 kB │ map: 1,679.42 kB
dist/index.umd.min.js  684.28 kB │ gzip: 265.02 kB │ map: 1,620.09 kB
```

to

```
dist/index.es.min.js  236.97 kB │ gzip: 123.79 kB │ map: 314.05 kB
dist/index.umd.min.js  225.44 kB │ gzip: 122.44 kB │ map: 310.74 kB
```

The impact on hyparquet+demo:

from

```
dist/assets/index-D_yEg-np.js         509.54 kB │ gzip: 213.44 kB
```

to

```
dist/assets/index-qQe6yLHC.js         366.69 kB │ gzip: 167.75 kB
```