### PR TITLE
improve the readme

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,3 +1,11 @@
 # Utility functions for hyparam apps
 
 This package contains utility functions for the hyparam apps.
+
+It depends on [hyparquet](https://github.com/hyparam/hyparquet), [hyparquet-compressors](https://github.com/hyparam/hyparquet-compressors) and [hightable](https://github.com/hyparam/hightable/).
+
+It is used in:
+- [hyperparam-cli](https://github.com/hyparam/hyperparam-cli/tree/master/apps/cli)
+- [hyparquet-demo](https://github.com/hyparam/hyperparam-cli/tree/master/apps/hyparquet-demo)
+- [hightable-demo](https://github.com/hyparam/hyperparam-cli/tree/master/apps/hightable-demo)
+- [@hyparam/components](https://github.com/hyparam/hyperparam-cli/tree/master/packages/components)


### PR DESCRIPTION
Note that the package version 0.1.0 pushed to npm (https://www.npmjs.com/package/@hyparam/utils/v/0.1.0) includes this change. I'll set the tag after merging.