### PR TITLE
[components] upgrade the dependencies

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,9 +21,9 @@
   "types": "es/index.d.ts",
   "exports": {
     ".": {
+      "types": "./es/index.d.ts",
       "import": "./dist/index.es.min.js",
-      "require": "./dist/index.umd.min.js",
-      "types": "./es/index.d.ts"
+      "require": "./dist/index.umd.min.js"
     }
   },
   "files": [
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "hightable": "0.7.2",
-    "hyparquet": "1.6.1",
+    "hyparquet": "1.6.3",
     "hyparquet-compressors": "0.1.4"
   },
   "peerDependencies": {
@@ -48,22 +48,22 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@eslint/js": "9.14.0",
+    "@eslint/js": "9.16.0",
     "@testing-library/react": "16.0.1",
-    "@types/node": "22.9.0",
+    "@types/node": "22.10.1",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "@vitejs/plugin-react": "4.3.3",
-    "@vitest/coverage-v8": "2.1.4",
-    "eslint": "9.14.0",
+    "@vitejs/plugin-react": "4.3.4",
+    "@vitest/coverage-v8": "2.1.8",
+    "eslint": "9.16.0",
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.0.0",
-    "eslint-plugin-react-refresh": "0.4.14",
-    "globals": "15.11.0",
+    "eslint-plugin-react-refresh": "0.4.16",
+    "globals": "15.13.0",
     "jsdom": "25.0.1",
-    "typescript": "5.6.3",
-    "typescript-eslint": "8.13.0",
-    "vite": "5.4.10",
-    "vitest": "2.1.4"
+    "typescript": "5.7.2",
+    "typescript-eslint": "8.17.0",
+    "vite": "5.4.11",
+    "vitest": "2.1.8"
   }
 }


### PR DESCRIPTION
hyparquet: 1.6.3

Note that vitest is not yet compatible with vite v6, so I kept vite in v5.

Also: move "types" above "import" and "require" in "exports", otherwise it's ignored.