### PR TITLE
Slide panel: use css for max width, and disable transition on drag

### DIFF
--- a/packages/cli/public/styles.css
+++ b/packages/cli/public/styles.css
@@ -50,6 +50,9 @@ a:hover {
   color: #000;
   text-decoration: underline;
 }
+button {
+  cursor: pointer;
+}
 
 /* layout */
 main {
@@ -251,6 +254,7 @@ main {
   display: flex;
   gap: 16px;
   height: 24px;
+  overflow: hidden;
   padding: 0 8px;
   /* all one line */
   text-overflow: ellipsis;
@@ -324,6 +328,7 @@ main {
   display: flex;
   flex: 1;
   flex-direction: column;
+  min-width: 100px;
   overflow: auto;
 }
 
@@ -332,6 +337,10 @@ main {
   flex-direction: column;
   width: 0;
   transition: width 0.2s;
+}
+
+.slideDragging {
+  transition: none;
 }
 
 .resizer {
@@ -354,10 +363,9 @@ main {
   background: none;
   border: none;
   color: inherit;
-  margin-left: auto;
   height: 24px;
+  margin-right: auto;
   outline: none;
-  padding: 0;
 }
 .slideClose::before {
   content: "\27E9\27E9";

--- a/packages/cli/src/AppComponent.js
+++ b/packages/cli/src/AppComponent.js
@@ -28,7 +28,7 @@ export default function App() {
     source,
     navigation: { row, col },
     config: {
-      slidePanel: { minWidth: 250, maxWidth: 750 },
+      slidePanel: {},
       routes: {
         getSourceRouteUrl: ({ source }) => `/files?key=${source}`,
         getCellRouteUrl: ({ source, col, row }) => `/files?key=${source}&col=${col}&row=${row}`,

--- a/packages/components/src/components/viewers/CellPanel.tsx
+++ b/packages/components/src/components/viewers/CellPanel.tsx
@@ -39,9 +39,9 @@ export default function CellPanel({ df, row, col, setProgress, setError, onClose
   }, [df, col, row, setProgress, setError])
 
   const headers = <>
+    <button className="slideClose" onClick={onClose}>&nbsp;</button>
     <span>column `{df.header[col]}`</span>
     <span>row {row + 1}</span>
-    <button className="slideClose" onClick={onClose}>&nbsp;</button>
   </>
 
   return <ContentHeader headers={headers}>

--- a/packages/components/src/components/viewers/SlidePanel.tsx
+++ b/packages/components/src/components/viewers/SlidePanel.tsx
@@ -16,7 +16,6 @@ interface SlidePanelProps {
 
 const WIDTH = {
   MIN: 100,
-  MAX: 800,
   DEFAULT: 400,
 } as const
 


### PR DESCRIPTION
This changes the behavior of the slide panel:

 - Disables the `transition` effect when dragging so that the browser doesn't lag.
 - Removes the `maxWidth` field so that users can use the full width of their screen, if they want.
 - Fix the resizer to better handle the case when the panel width exceeds the available area.
 - Change the position of the "close" button to the left so that it doesn't get pushed off screen

This requires components and cli to be updated together or else the close button will be misaligned.