### PR TITLE
get the version from the JSON file explicitly

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'fs/promises'
+import hyperparamPackage from '../package.json' with { type: 'json' }
 import { chat } from './chat.js'
 import { serve } from './serve.js'
 
@@ -16,7 +17,7 @@ if (arg === 'chat') {
   console.log('  hyperparam -h, --help,    give this help list')
   console.log('  hyperparam -v, --version  print program version')
 } else if (arg === '--version' || arg === '-V' || arg === '-v') {
-  console.log(process.env.npm_package_version)
+  console.log(hyperparamPackage.version)
 } else if (!arg) {
   serve(process.cwd(), undefined) // current directory
 } else if (arg.match(/^https?:\/\//)) {


### PR DESCRIPTION
I checked it worked by doing:

```
$ npm pack
...
npm notice                         
hyperparam-0.2.10.tgz
$ cd /tmp
$ npm add -g PATH_TO_CLI/hyperparam-0.2.10.tgz
...
$ hyp -h
Usage:
  hyperparam [path]         start hyperparam webapp. "path" is a directory or a URL.
                            defaults to the current directory.
  hyperparam chat           start chat client
  
  hyperparam -h, --help,    give this help list
  hyperparam -v, --version  print program version
$ hyp -v
0.2.10
```