### PR TITLE
Fixes #3: show the folders above the files in the Folder view

### DIFF
--- a/packages/cli/src/serve.js
+++ b/packages/cli/src/serve.js
@@ -209,6 +209,30 @@ async function handleListing(prefix) {
       })
     }
   }
+  files.sort((a, b) => {
+    const isDirA = a.key.endsWith("/");
+    const isDirB = b.key.endsWith("/");
+
+    // Prioritize directories over files
+    if (isDirA && !isDirB) return -1;
+    if (!isDirA && isDirB) return 1;
+
+    // Check for dot folders/files and special char folders/files
+    const isDotFolderA = a.key.startsWith(".");
+    const isDotFolderB = b.key.startsWith(".");
+    const hasSpecialCharsA = /[^a-zA-Z0-9]/.test(a.key);
+    const hasSpecialCharsB = /[^a-zA-Z0-9]/.test(b.key);
+
+    // Handle dot folders/files first
+    if (isDotFolderA && !isDotFolderB) return -1;
+    if (!isDotFolderA && isDotFolderB) return 1;
+
+    // Handle special character folders/files second
+    if (hasSpecialCharsA && !hasSpecialCharsB) return 1;
+    if (!hasSpecialCharsA && hasSpecialCharsB) return -1;
+
+    return a.key.localeCompare(b.key);
+  });
 
   return { status: 200, content: JSON.stringify(files), contentType: 'application/json' }
 }

--- a/packages/cli/src/serve.js
+++ b/packages/cli/src/serve.js
@@ -181,7 +181,7 @@ async function handleHead(filePath) {
  * @param {string} prefix file path prefix
  * @returns {Promise<ServeResult>}
  */
-async function handleListing(prefix) {
+export async function handleListing(prefix) {
   try {
     const stat = await fs.stat(prefix)
     if (!stat.isDirectory()) return { status: 400, content: 'not a directory' }

--- a/packages/cli/test/handleListing.test.js
+++ b/packages/cli/test/handleListing.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import * as fs from "fs/promises";
+import path from "path";
+import { handleListing } from "../src/serve.js";
+
+const tempDir = path.join(__dirname, "temp-test-dir");
+
+describe("handleListing", () => {
+  const testFiles = [
+    { name: ".dotfile.txt", type: "file", content: "Dot file content" },
+    { name: "dir1", type: "dir" },
+    { name: "file.txt", type: "file", content: "File content" },
+    { name: "@specialFolder", type: "dir" },
+    { name: "dir2", type: "dir" },
+    { name: "Unicode_文件.txt", type: "file", content: "Unicode file content" },
+    { name: "app.jsx", type: "file", content: "File content" },
+  ];
+
+  beforeAll(async () => {
+    await fs.mkdir(tempDir, { recursive: true });
+    for (const file of testFiles) {
+      const filePath = path.join(tempDir, file.name);
+      if (file.type === "dir") await fs.mkdir(filePath);
+      else await fs.writeFile(filePath, file.content || "");
+    }
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should return directories before files in case-insensitive alphabetical order", async () => {
+    const result = await handleListing(tempDir);
+    if (typeof result.content !== "string") {
+      throw new Error("Expected result.content to be a string");
+    }
+
+    /**
+     * Parsed entries from the result.
+     * @type {{ key: string, fileSize?: number, lastModified: string }[]}
+     */
+    const entries = JSON.parse(result.content);
+    const keys = entries.map((entry) => entry.key);
+    const expectedKeys = [
+      "@specialFolder/",
+      "dir1/",
+      "dir2/",
+      ".dotfile.txt",
+      "app.jsx",
+      "file.txt",
+      "Unicode_文件.txt",
+    ];
+
+    expect(keys).toEqual(expectedKeys);
+  });
+});


### PR DESCRIPTION
This PR implements a sorting feature to the file viewing API (issue #3) :

- Directories are now prioritised over files.
- Files and directories starting with a dot (e.g., .gitignore) are placed first.
- Files and directories with special characters are handled next (e.g., @rollup).
- Remaining items are sorted alphabetically in a case-insensitive manner.

This change improves the organisation of files and directories, making it easier to navigate and manage content. 
Let me know if there are any optimisations or suggestions for this PR.