### PR TITLE
fix: resolve cli failure on npm run serve in directories with whitespaces

### DIFF
--- a/packages/cli/src/serve.js
+++ b/packages/cli/src/serve.js
@@ -78,9 +78,9 @@ function handleRequest(req, serveDirectory) {
   const pathname = parsedUrl.pathname || ''
 
   // get location of hyperparam assets
-  const hyperparamPath = import.meta.url
+  const hyperparamPath = decodeURIComponent(import.meta.url
     .replace('file://', '')
-    .replace('/src/serve.js', '')
+    .replace('/src/serve.js', ''))
 
   if (pathname === '/' || pathname === '/files/') {
     // redirect to /files

--- a/packages/cli/src/serve.js
+++ b/packages/cli/src/serve.js
@@ -78,9 +78,9 @@ function handleRequest(req, serveDirectory) {
   const pathname = parsedUrl.pathname || ''
 
   // get location of hyperparam assets
-  const hyperparamPath = decodeURIComponent(import.meta.url
+  const hyperparamPath = decodeURIComponent(import.meta.url)
     .replace('file://', '')
-    .replace('/src/serve.js', ''))
+    .replace('/src/serve.js', '')
 
   if (pathname === '/' || pathname === '/files/') {
     // redirect to /files


### PR DESCRIPTION
This PR resolve issue #143

**Issue:** 
The `npm run serve` command fails when project is located in directory path with white-spaces, resulting "not found" error.

**Resolution:** 
Implemented decodeURIComponent for hyperparamPath to correctly handle file paths with white-spaces.
