### PR TITLE
run CI on pull_request, not on push

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -1,6 +1,6 @@
 name: check dependencies
 on:
-  push:
+  pull_request:
     paths:
       - '**/package.json'
       - '.github/workflows/check_dependencies.yml'

--- a/.github/workflows/ci_apps_hightable_demo.yml
+++ b/.github/workflows/ci_apps_hightable_demo.yml
@@ -1,6 +1,6 @@
 name: apps/hightable-demo
 on:
-  push:
+  pull_request:
     paths:
       - 'apps/hightable-demo/**'
       - '.github/workflows/_common_jobs.yml'

--- a/.github/workflows/ci_apps_hyparquet_demo.yml
+++ b/.github/workflows/ci_apps_hyparquet_demo.yml
@@ -1,6 +1,6 @@
 name: apps/hyparquet-demo
 on:
-  push:
+  pull_request:
     paths:
       - 'packages/components/**'
       - 'apps/hyparquet-demo/**'

--- a/.github/workflows/ci_packages_cli.yml
+++ b/.github/workflows/ci_packages_cli.yml
@@ -1,6 +1,6 @@
 name: apps/cli
 on:
-  push:
+  pull_request:
     paths:
       - 'packages/components/**'
       - 'packages/cli/**'

--- a/.github/workflows/ci_packages_components.yml
+++ b/.github/workflows/ci_packages_components.yml
@@ -1,6 +1,6 @@
 name: packages/components
 on:
-  push:
+  pull_request:
     paths:
       - 'packages/components/**'
       - '.github/workflows/_common_jobs.yml'

--- a/.github/workflows/ci_root.yml
+++ b/.github/workflows/ci_root.yml
@@ -1,6 +1,6 @@
 name: root
 on:
-  push:
+  pull_request:
     paths:
       - '*'
       - 'test/**'


### PR DESCRIPTION
1. we force using prs to push to master
2. it runs the CI on prs from forked repos

Note that the deployment action is still run on push to master.