### PR TITLE
upgrade deps, downgrade to react 18, publish versions

### DIFF
--- a/apps/hightable-demo/package.json
+++ b/apps/hightable-demo/package.json
@@ -14,9 +14,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "hightable": "0.9.2",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "react-router": "7.1.3"
+    "hightable": "0.10.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-router": "7.1.5"
   }
 }

--- a/apps/hightable-demo/src/data.tsx
+++ b/apps/hightable-demo/src/data.tsx
@@ -1,4 +1,4 @@
-import { rowCache, sortableDataFrame, wrapPromise } from 'hightable'
+import { AsyncRow, rowCache, sortableDataFrame, wrapPromise } from 'hightable'
 
 function lorem(rand: number, length: number): string {
   const words = 'lorem ipsum dolor sit amet consectetur adipiscing elit'.split(' ')
@@ -15,7 +15,7 @@ const mockData = {
   header,
   numRows: 10000,
   rows(start: number, end: number) {
-    const arr: Record<string, ReturnType<typeof wrapPromise<string | number>>>[] = []
+    const arr: AsyncRow[] = []
     for (let i = start; i < end; i++) {
       const rand = Math.abs(Math.sin(i + 1))
       const uuid = rand.toString(16).substring(2)
@@ -28,11 +28,14 @@ const mockData = {
       }
       const row = { ...partial, JSON: JSON.stringify(partial) }
       // Map to randomly delayed promises
-      const promised = Object.fromEntries(Object.entries(row).map(([key, value]) =>
+      const cells = Object.fromEntries(Object.entries(row).map(([key, value]) =>
         // discrete time delay for each cell to simulate async data loading
         [key, wrapPromise(delay(value, 100 * Math.floor(10 * Math.random())))],
       ))
-      arr.push(promised)
+      arr.push({
+        index: wrapPromise(i),
+        cells,
+      })
     }
     return arr
   },

--- a/apps/hyparquet-demo/package.json
+++ b/apps/hyparquet-demo/package.json
@@ -14,11 +14,11 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@hyparam/components": "0.1.15",
-    "hightable": "0.9.2",
-    "hyparquet": "1.8.1",
+    "@hyparam/components": "0.1.16",
+    "hightable": "0.10.0",
+    "hyparquet": "1.8.2",
     "hyparquet-compressors": "1.0.0",
-    "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   }
 }

--- a/apps/hyparquet-demo/src/App.tsx
+++ b/apps/hyparquet-demo/src/App.tsx
@@ -2,9 +2,9 @@ import { ReactNode } from 'react'
 import Page, { PageProps } from './Page.js'
 import Welcome from './Welcome.js'
 
-import { AsyncBufferFrom, Row, asyncBufferFrom, parquetQueryWorker } from '@hyparam/components'
-import { DataFrame, rowCache } from 'hightable'
-import { FileMetaData, byteLengthFromUrl, parquetMetadataAsync, parquetSchema } from 'hyparquet'
+import { AsyncBufferFrom, asyncBufferFrom, parquetDataFrame } from '@hyparam/components'
+import { rowCache } from 'hightable'
+import { byteLengthFromUrl, parquetMetadataAsync } from 'hyparquet'
 import { useCallback, useEffect, useState } from 'react'
 import Dropzone from './Dropzone.js'
 import Layout from './Layout.js'
@@ -58,26 +58,4 @@ export default function App(): ReactNode {
       {pageProps ? <Page {...pageProps} /> : <Welcome />}
     </Dropzone>
   </Layout>
-}
-
-/**
- * Convert a parquet file into a dataframe.
- */
-function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData): DataFrame {
-  const { children } = parquetSchema(metadata)
-  return {
-    header: children.map(child => child.element.name),
-    numRows: Number(metadata.num_rows),
-    /**
-     * @param {number} rowStart
-     * @param {number} rowEnd
-     * @param {string} orderBy
-     * @returns {Promise<any[][]>}
-     */
-    rows(rowStart: number, rowEnd: number, orderBy: string): Promise<Row[]> {
-      console.log(`reading rows ${rowStart}-${rowEnd}`, orderBy)
-      return parquetQueryWorker({ from, metadata, rowStart, rowEnd, orderBy })
-    },
-    sortable: true,
-  }
 }

--- a/package.json
+++ b/package.json
@@ -16,28 +16,28 @@
   },
   "overrides": {
     "highlight.js": "11.11.1",
-    "hightable": "0.9.2",
-    "hyparquet": "1.8.1",
+    "hightable": "0.10.0",
+    "hyparquet": "1.8.2",
     "hyparquet-compressors": "1.0.0",
-    "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@testing-library/react": "16.2.0",
-    "@types/node": "22.12.0",
+    "@types/node": "22.13.1",
     "@types/react": "19.0.8",
     "@types/react-dom": "19.0.3",
     "@vitejs/plugin-react": "4.3.4",
-    "@vitest/coverage-v8": "3.0.4",
-    "eslint": "9.19.0",
+    "@vitest/coverage-v8": "3.0.5",
+    "eslint": "9.20.0",
     "eslint-plugin-react": "7.37.4",
     "eslint-plugin-react-hooks": "5.1.0",
-    "eslint-plugin-react-refresh": "0.4.18",
+    "eslint-plugin-react-refresh": "0.4.19",
     "globals": "15.14.0",
     "jsdom": "26.0.0",
     "typescript": "5.7.3",
-    "typescript-eslint": "8.22.0",
-    "vite": "6.0.11",
-    "vitest": "3.0.4"
+    "typescript-eslint": "8.24.0",
+    "vite": "6.1.0",
+    "vitest": "3.0.5"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperparam",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Hyperparam CLI",
   "author": "Hyperparam",
   "homepage": "https://hyperparam.app",
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "highlight.js": "11.11.1",
-    "hightable": "0.9.2",
-    "@hyparam/components": "0.1.15",
-    "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "hightable": "0.10.0",
+    "@hyparam/components": "0.1.16",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "28.0.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyparam/components",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "React components for hyparam apps",
   "keywords": [
     "component",
@@ -40,12 +40,16 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "hightable": "0.9.2",
-    "hyparquet": "1.8.1",
+    "hightable": "0.10.0",
+    "hyparquet": "1.8.2",
     "hyparquet-compressors": "1.0.0"
   },
   "peerDependencies": {
-    "react": ">=18.3.1",
-    "react-dom": ">=18.3.1"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   }
 }

--- a/packages/components/src/components/viewers/CellPanel.tsx
+++ b/packages/components/src/components/viewers/CellPanel.tsx
@@ -1,4 +1,4 @@
-import { DataFrame, asyncRows, stringify } from 'hightable'
+import { DataFrame, stringify } from 'hightable'
 import { useEffect, useState } from 'react'
 import ContentHeader from './ContentHeader.js'
 
@@ -22,11 +22,13 @@ export default function CellPanel({ df, row, col, setProgress, setError, onClose
     async function loadCellData() {
       try {
         setProgress(0.5)
-        const rows = df.rows(row, row + 1)
-        // Convert to AsyncRows
-        const asyncRow = asyncRows(rows, 1, df.header)[0]
+        const asyncRows = df.rows(row, row + 1)
+        if (asyncRows.length !== 1) {
+          throw new Error(`Expected 1 row, got ${asyncRows.length}`)
+        }
+        const asyncRow = asyncRows[0]
         // Await cell data
-        const text = await asyncRow[df.header[col]].then(stringify)
+        const text = await asyncRow.cells[df.header[col]].then(stringify)
         setText(text)
       } catch (error) {
         setError(error as Error)

--- a/packages/components/src/lib/tableProvider.ts
+++ b/packages/components/src/lib/tableProvider.ts
@@ -11,7 +11,6 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
   const header = children.map(child => child.element.name)
   const sortCache = new Map<string, Promise<number[]>>()
   const data = new Array<ResolvableRow | undefined>(Number(metadata.num_rows))
-  /// ^ warning: the type is a lie at that point, because all rows are undefined for now
   const groups = new Array(metadata.row_groups.length).fill(false)
   let groupStart = 0
   const groupEnds = metadata.row_groups.map(group => groupStart += Number(group.num_rows))

--- a/packages/components/src/lib/tableProvider.ts
+++ b/packages/components/src/lib/tableProvider.ts
@@ -1,9 +1,7 @@
-import { DataFrame, ResolvablePromise, resolvablePromise } from 'hightable'
+import { DataFrame, ResolvableRow, resolvableRow } from 'hightable'
 import { FileMetaData, parquetSchema } from 'hyparquet'
 import { parquetQueryWorker, parquetSortIndexWorker } from './workers/parquetWorkerClient.js'
 import type { AsyncBufferFrom } from './workers/types.d.ts'
-
-type ResolvableRow = Record<string, ResolvablePromise<unknown>>;
 
 /**
  * Convert a parquet file into a dataframe.
@@ -12,7 +10,7 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
   const { children } = parquetSchema(metadata)
   const header = children.map(child => child.element.name)
   const sortCache = new Map<string, Promise<number[]>>()
-  const data = new Array<ResolvableRow>(Number(metadata.num_rows))
+  const data = new Array<ResolvableRow | undefined>(Number(metadata.num_rows))
   /// ^ warning: the type is a lie at that point, because all rows are undefined for now
   const groups = new Array(metadata.row_groups.length).fill(false)
   let groupStart = 0
@@ -24,18 +22,16 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
       const rowEnd = groupEnds[groupIndex]
       // Initialize with resolvable promises
       for (let i = rowStart; i < rowEnd; i++) {
-        data[i] = Object.fromEntries(
-          header.map((key) => [key, resolvablePromise<unknown>()]),
-          // ^ for type: resolvableRow uses any, not unknown
-        )
+        data[i] = resolvableRow(header)
       }
       parquetQueryWorker({ from, metadata, rowStart, rowEnd })
         .then((groupData) => {
           for (let i = rowStart; i < rowEnd; i++) {
+            data[i]?.index.resolve(i)
             for (const [key, value] of Object.entries(
               groupData[i - rowStart],
             )) {
-              data[i]?.[key].resolve(value)
+              data[i]?.cells[key].resolve(value)
             }
           }
         })
@@ -61,8 +57,7 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
     rows(rowStart: number, rowEnd: number, orderBy?: string) {
       if (orderBy) {
         const numRows = rowEnd - rowStart
-        const wrapped = new Array<ResolvableRow | null>(numRows).fill(null)
-          .map(() => Object.fromEntries(header.map((key) => [key, resolvablePromise()])))
+        const wrapped = new Array(numRows).fill(null).map(() => resolvableRow(header))
 
         getSortIndex(orderBy).then(indices => {
           // Compute row groups to fetch
@@ -73,17 +68,20 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
 
           // Re-assemble data in sorted order into wrapped
           for (let i = rowStart; i < rowEnd; i++) {
-            const row = data[indices[i]]
-            // Add index to wrapped row
-            const indexPromise = resolvablePromise()
-            indexPromise.resolve(indices[i])
-            wrapped[i - rowStart].__index__ = indexPromise
+            const index = indices[i]
+            const row = data[index]
+            if (row === undefined) {
+              throw new Error('Row not fetched')
+            }
+            const { cells } = row
+            wrapped[i - rowStart].index.resolve(index)
             for (const key of header) {
-              if (key in row) {
-                const cell = row[key]
-                cell
+              if (key in cells) {
+                // TODO(SL): should we remove this check? It makes sense only if header change
+                // but if so, I guess we will have more issues
+                cells[key]
                   .then((value: unknown) => {
-                    wrapped[i - rowStart]?.[key].resolve(value)
+                    wrapped[i - rowStart]?.cells[key].resolve(value)
                   })
                   .catch((error: unknown) => {
                     console.error('Error resolving sorted row', error)
@@ -106,7 +104,11 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
             fetchRowGroup(i)
           }
         }
-        return data.slice(rowStart, rowEnd)
+        const wrapped = data.slice(rowStart, rowEnd)
+        if (wrapped.some(row => row === undefined)) {
+          throw new Error('Row not fetched')
+        }
+        return wrapped as ResolvableRow[]
       }
     },
     sortable: true,


### PR DESCRIPTION
- [x] Missing: modify the parquetWorker to return AsyncRow[] or transform them from Promise<Row[]> after using it (the tricky part is getting the index if sorted). OK, I just used parquetDataFrame from @hyparam/components.