### PR TITLE
Markdown recursive parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/hyperparam)](https://www.npmjs.com/package/hyperparam)
 [![workflow status](https://github.com/hyparam/hyperparam-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/hyparam/hyperparam-cli/actions)
 [![mit license](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![coverage](https://img.shields.io/badge/Coverage-51-darkred)
+![coverage](https://img.shields.io/badge/Coverage-56-darkred)
 
 This is the hyperparam cli tool.
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -327,9 +327,9 @@ function gzip(req, content) {
  */
 function openUrl(url) {
   switch (process.platform) {
-  case 'darwin': exec(`open ${url}`); return
-  case 'win32': exec(`start ${url}`); return
-  case 'linux': exec(`xdg-open ${url}`); return
-  default: throw new Error(`unsupported platform ${process.platform}`)
+    case 'darwin': exec(`open ${url}`); return
+    case 'win32': exec(`start ${url}`); return
+    case 'linux': exec(`xdg-open ${url}`); return
+    default: throw new Error(`unsupported platform ${process.platform}`)
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,7 @@ export default typescript.config(
       'eol-last': 'error',
       eqeqeq: 'error',
       'func-style': ['error', 'declaration'],
-      indent: ['error', 2],
+      indent: ['error', 2, { SwitchCase: 1 }],
       'no-constant-condition': 'off',
       'no-extra-parens': 'error',
       'no-multi-spaces': 'error',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build:types": "tsc -b",
     "build:lib": "vite build -c vite.lib.config.js",
-    "build:app": "vite build -c vite.app.config.js",
+    "build:app": "vite build",
     "build": "run-s build:lib build:types build:app",
     "coverage": "vitest run -c vite.lib.config.js --coverage --coverage.include=src --coverage.include=bin",
     "dev": "run-p -l watch:ts watch:vite watch:serve",
@@ -38,7 +38,7 @@
     "prepublishOnly": "npm run build",
     "serve": "node bin/cli.js",
     "preserve": "npm run build",
-    "test": "vitest run -c vite.lib.config.js",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "url": "run-p -l watch:ts watch:vite watch:url",
     "watch:ts": "tsc --watch",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21,8 +21,33 @@ button:hover {
   background-color: #333;
 }
 
+/* inline code block */
 code {
   font-family: monospace;
+}
+
+h1 {
+  font-size: 32px;
+  font-weight: 500;
+  margin-bottom: 8px;
+}
+h2 {
+  font-weight: 500;
+  margin-bottom: 8px;
+  margin-top: 16px;
+}
+h3 {
+  margin-bottom: 8px;
+  margin-top: 16px;
+}
+
+ol,
+ul {
+  margin: 10px 0;
+  padding: 0 0 0 20px;
+}
+li {
+  margin: 4px 0;
 }
 
 #app {

--- a/test/components/Markdown.test.tsx
+++ b/test/components/Markdown.test.tsx
@@ -61,28 +61,14 @@ describe('Markdown', () => {
     expect(links[1].getAttribute('href')).toBe('https://github.com/hyparam')
   })
 
-  it('renders a list', () => {
-    const text = '- Item 1\n- Item 2\n- Item 3\n\n'
+  it('renders blockquote', () => {
+    const text = '> This is a blockquote.'
     const { getByText } = render(<Markdown text={text} />)
-    expect(getByText('Item 1')).toBeDefined()
-    expect(getByText('Item 2')).toBeDefined()
-    expect(getByText('Item 3')).toBeDefined()
+    expect(getByText('This is a blockquote.')).toBeDefined()
   })
+})
 
-  it('renders an list with bold', () => {
-    const text = '- **Item 1**\n- Item 2\n- Item 3\n\n'
-    const { getByText } = render(<Markdown text={text} />)
-    expect(getByText('Item 1')).toBeDefined()
-    expect(getByText('Item 2')).toBeDefined()
-    expect(getByText('Item 3')).toBeDefined()
-  })
-
-  it('render an unterminated list', () => {
-    const text = '- Item 1'
-    const { getByText } = render(<Markdown text={text} />)
-    expect(getByText('Item 1')).toBeDefined()
-  })
-
+describe('Markdown code blocks', () => {
   it('renders a code block', () => {
     const text = '```js\nconsole.log(\'Hello, world!\')\n```'
     const { container } = render(<Markdown text={text} />)
@@ -98,9 +84,143 @@ describe('Markdown', () => {
     expect(code).toBeDefined()
     expect(code?.textContent).toBe('console.log(\'Hello, world!\')')
   })
+
+  it('renders a bold code block', () => {
+    const text = '**`Math.pow(base, exponent)`**'
+    const { container, getByText } = render(<Markdown text={text} />)
+    expect(getByText('Math.pow(base, exponent)')).toBeDefined()
+    expect(container.innerHTML).not.toContain('**')
+  })
+
+  it('renders markdown inside a code block as literal text', () => {
+    const text = `\`\`\`
+**This should not be bold**
+*nor italic*
+\`\`\``
+    const { container } = render(<Markdown text={text} />)
+    const codeBlock = container.querySelector('pre')
+    expect(codeBlock).toBeDefined()
+    expect(codeBlock?.textContent).toContain('**This should not be bold**')
+    expect(codeBlock?.textContent).toContain('*nor italic*')
+    // Ensure markdown inside code block is not parsed
+    expect(container.innerHTML).not.toContain('<strong>')
+    expect(container.innerHTML).not.toContain('<em>')
+  })
+})
+
+describe('Markdown lists', () => {
+  it('renders a list', () => {
+    const text = '- Item 1\n- Item 2\n- Item 3\n\n'
+    const { container, getByText } = render(<Markdown text={text} />)
+    expect(getByText('Item 1')).toBeDefined()
+    expect(getByText('Item 2')).toBeDefined()
+    expect(getByText('Item 3')).toBeDefined()
+    // Should have no <p> tags for simple lists
+    expect(container.querySelectorAll('p').length).toBe(0)
+  })
+
+  it('renders a list with bold', () => {
+    const text = '- **Item 1**\n- Item 2\n- Item 3\n\n'
+    const { getByText } = render(<Markdown text={text} />)
+    expect(getByText('Item 1')).toBeDefined()
+    expect(getByText('Item 2')).toBeDefined()
+    expect(getByText('Item 3')).toBeDefined()
+  })
+
+  it('renders a list with indented sub-paragraphs', () => {
+    const text = '- Item 1\n  Paragraph 1\n  Paragraph 2\n- Item 2\n\n'
+    const { container, getByText } = render(<Markdown text={text} />)
+    expect(getByText('Item 1')).toBeDefined()
+    expect(getByText('Paragraph 1')).toBeDefined()
+    expect(getByText('Paragraph 2')).toBeDefined()
+    expect(getByText('Item 2')).toBeDefined()
+    // Should have <p> tags for paragraphs
+    expect(container.querySelectorAll('p').length).toBe(2)
+  })
+
+  it('renders an unterminated list', () => {
+    const text = '- Item 1'
+    const { getByText } = render(<Markdown text={text} />)
+    expect(getByText('Item 1')).toBeDefined()
+  })
+
+  it('renders nested unordered list with sub-items', () => {
+    const text = `- Parent item
+  - Child item
+    - Grandchild item`
+    const { getByText } = render(<Markdown text={text} />)
+    expect(getByText('Parent item')).toBeDefined()
+    expect(getByText('Child item')).toBeDefined()
+    expect(getByText('Grandchild item')).toBeDefined()
+  })
+
+  it('renders nested ordered list', () => {
+    const text = `1. First item
+   1. Nested item
+   2. Another nested item
+2. Second item`
+    const { getByText } = render(<Markdown text={text} />)
+    expect(getByText('First item')).toBeDefined()
+    expect(getByText('Nested item')).toBeDefined()
+    expect(getByText('Another nested item')).toBeDefined()
+    expect(getByText('Second item')).toBeDefined()
+  })
+
+  it('handles blank lines in lists', () => {
+    const text = '- Item 1\n\n- Item 2\n\n- Item 3'
+    const { container, getByText } = render(<Markdown text={text} />)
+    expect(getByText('Item 1')).toBeDefined()
+    expect(getByText('Item 2')).toBeDefined()
+    expect(getByText('Item 3')).toBeDefined()
+    expect(container.querySelectorAll('ul').length).toBe(1)
+    expect(container.querySelectorAll('li').length).toBe(3)
+  })
+
+  it('renders inline code inside a nested list with mixed formatting', () => {
+    const text = `- Item with inline code: \`const x = 10;\`
+  - Child item with **bold** text and \`inline code\``
+    const { getByText, container } = render(<Markdown text={text} />)
+    // Check for the plain text parts
+    expect(getByText('Item with inline code:')).toBeDefined()
+    expect(getByText('const x = 10;')).toBeDefined()
+    expect(getByText('bold')).toBeDefined()
+    expect(getByText('inline code')).toBeDefined()
+    // Verify that inline code elements exist
+    const inlineCodes = container.querySelectorAll('code')
+    expect(inlineCodes.length).toBe(2)
+  })
+
+  it('renders a nested code block within a list item', () => {
+    const text = `- List item with code:
+  \`\`\`js
+  console.log("Nested code")
+  \`\`\``
+    const { container, getByText } = render(<Markdown text={text} />)
+    expect(getByText('List item with code:')).toBeDefined()
+    expect(getByText('console.log("Nested code")')).toBeDefined()
+    const codeBlock = container.querySelector('pre')
+    expect(codeBlock).toBeDefined()
+    expect(codeBlock?.textContent).toContain('console.log("Nested code")')
+  })
 })
 
 describe('Markdown with nested elements', () => {
+  it('renders nested formatting with bold, italic, and inline code', () => {
+    const text = 'This is **bold text with *italic and `code` inside* text**.'
+    const { container } = render(<Markdown text={text} />)
+    // Check for inline code element
+    const codeElem = container.querySelector('code')
+    expect(codeElem).toBeDefined()
+    // Check for italic element that should contain the inline code
+    const italicElem = container.querySelector('em')
+    expect(italicElem).toBeDefined()
+    expect(italicElem?.textContent).toContain('code')
+    // The bold text should wrap the entire content
+    const boldElem = container.querySelector('strong')
+    expect(boldElem).toBeDefined()
+    expect(boldElem?.textContent).toContain('bold text with')
+  })
+
   it('renders an image inside a link', () => {
     const text = '[![mit license](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT)'
     const { container } = render(<Markdown text={text} />)
@@ -157,5 +277,47 @@ describe('Markdown with nested elements', () => {
     expect(img).toBeDefined()
     expect(img?.getAttribute('src')).toBe('https://example.com/icon.png')
     expect(link?.contains(img)).toBe(true)
+  })
+
+  it('handles incomplete image syntax without closing bracket', () => {
+    const text = '![alt'
+    const { container } = render(<Markdown text={text} />)
+
+    console.log(container.innerHTML)
+    expect(container.textContent).toBe('![alt')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('handles incomplete image syntax without closing parenthesis', () => {
+    const text = '![alt](https://example.com/image.png'
+    const { container } = render(<Markdown text={text} />)
+
+    expect(container.textContent).toBe('![alt](https://example.com/image.png')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('handles incomplete link syntax without closing bracket', () => {
+    const text = '[link'
+    const { container } = render(<Markdown text={text} />)
+
+    // The parser treats this as a text token with '['
+    expect(container.textContent).toBe('[')
+    expect(container.querySelector('a')).toBeNull()
+  })
+
+  it('handles unclosed image link', () => {
+    const text = '![alt]'
+    const { container } = render(<Markdown text={text} />)
+
+    expect(container.textContent).toBe('![alt]')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('handles unclosed link', () => {
+    const text = '[link]'
+    const { container } = render(<Markdown text={text} />)
+
+    expect(container.textContent).toBe('[link]')
+    expect(container.querySelector('a')).toBeNull()
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import { defineConfig } from 'vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: { environment: 'jsdom', globals: true },
 })


### PR DESCRIPTION
Upgrades the Markdown component from using regexes that were never going to work, to a recursive token parser that does better.

Lots more markdown tests added.

@severo I moved `vite.app.config.js` to `vite.config.ts` . This makes it so that `npx vitest` works without specifying the config file. Also switched to typescript for better typechecking of the config file (maybe should do same for vite.lib.config.js? can we combine those?).