### PR TITLE
Disable opening the browser when in development mode

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -57,10 +57,13 @@ export async function serve(serveDirectory, key) {
     }
   }
   console.log(`hyperparam server running on http://localhost:${port}`)
-  if (!key) openUrl(`http://localhost:${port}`)
-  else {
-    key = encodeURIComponent(key)
-    openUrl(`http://localhost:${port}/files?key=${key}`)
+  const isDev = process.env.NODE_ENV === 'development'
+  if (!isDev) {
+    if (!key) openUrl(`http://localhost:${port}`)
+    else {
+      key = encodeURIComponent(key)
+      openUrl(`http://localhost:${port}/files?key=${key}`)
+    }
   }
 }
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -91,9 +91,6 @@ function handleRequest(req, serveDirectory) {
   } else if (pathname.startsWith('/assets/') || pathname.startsWith('/favicon') ) {
     // serve static files
     return handleStatic(`${hyperparamPath}/dist${pathname}`)
-  // else if (pathname.startsWith('/public/')) {
-  //   // serve static files
-  //   return handleStatic(`${hyperparamPath}${pathname.replace(/^(\/public).*/, '/dist')}`)
   } else if (serveDirectory && pathname === '/api/store/list') {
     // serve file list
     const prefix = parsedUrl.query.prefix || ''

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -95,8 +95,8 @@ function handleRequest(req, serveDirectory) {
     // serve file list
     const prefix = parsedUrl.query.prefix || ''
     if (Array.isArray(prefix)) return { status: 400, content: 'bad request' }
-    const perfixPath = `${serveDirectory}/${decodeURIComponent(prefix)}`
-    return handleListing(perfixPath)
+    const prefixPath = `${serveDirectory}/${decodeURIComponent(prefix)}`
+    return handleListing(prefixPath)
   } else if (serveDirectory && pathname === '/api/store/get') {
     // serve file content
     const key = parsedUrl.query.key || ''

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "url": "run-p -l watch:ts watch:vite watch:url",
     "watch:ts": "tsc --watch",
     "watch:vite": "vite build --watch",
-    "watch:serve": "nodemon bin/cli.js",
-    "watch:url": "nodemon bin/cli.js https://hyperparam.blob.core.windows.net/hyperparam/starcoderdata-js-00000-of-00065.parquet"
+    "watch:serve": "NODE_ENV=development nodemon bin/cli.js",
+    "watch:url": "NODE_ENV=development nodemon bin/cli.js https://hyperparam.blob.core.windows.net/hyperparam/starcoderdata-js-00000-of-00065.parquet"
   },
   "dependencies": {
     "hightable": "0.12.1",


### PR DESCRIPTION
fixes #173 by disabling the automatic opening of a browser tab when the cli restarts.

It means that the workflow in dev would be:

- run `npm run dev`
- click the URL shown in the console logs (by default http://localhost:2048) to open in a browser
-  do some changes in the code -> the new app will be rebuild automatically and the CLI will be restarted too, but the opened tab will still show the outdated version
- manually update the browser tab.

A follow-up could be to set up browser-sync (I could not make it work easily) or another tool to open and reload a browser tab automatically.
