### PR TITLE
Add a typescript rule so that array<T>[i] is T | undefined

### DIFF
--- a/src/components/Folder.tsx
+++ b/src/components/Folder.tsx
@@ -47,7 +47,7 @@ export default function Folder({ source, config }: FolderProps) {
         setSearchQuery('')
       } else if (e.key === 'Enter') {
         // if there is only one result, view it
-        if (filtered?.length === 1) {
+        if (filtered?.length === 1 && 0 in filtered) {
           const key = join(source.prefix, filtered[0].name)
           if (key.endsWith('/')) {
             // clear search because we're about to change folder

--- a/src/components/viewers/CellPanel.tsx
+++ b/src/components/viewers/CellPanel.tsx
@@ -23,12 +23,21 @@ export default function CellPanel({ df, row, col, setProgress, setError, onClose
       try {
         setProgress(0.5)
         const asyncRows = df.rows({ start: row, end: row + 1 })
-        if (asyncRows.length !== 1) {
+        if (asyncRows.length > 1 || !(0 in asyncRows)) {
           throw new Error(`Expected 1 row, got ${asyncRows.length}`)
         }
         const asyncRow = asyncRows[0]
         // Await cell data
-        const text = await asyncRow.cells[df.header[col]].then(stringify)
+        const columnName = df.header[col]
+        if (columnName === undefined) {
+          throw new Error(`Column name missing at index col=${col}`)
+        }
+        const asyncCell = asyncRow.cells[columnName]
+        if (asyncCell === undefined) {
+          throw new Error(`Cell missing at column ${columnName}`)
+        }
+        /* TODO(SL): use the same implementation of stringify, here and in Cell.tsx */
+        const text = await asyncCell.then(cell => stringify(cell as unknown) ?? '{}')
         setText(text)
       } catch (error) {
         setError(error as Error)

--- a/src/components/viewers/ImageView.tsx
+++ b/src/components/viewers/ImageView.tsx
@@ -70,13 +70,13 @@ export default function ImageView({ source, setError }: ViewerProps) {
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   let binary = ''
   const bytes = new Uint8Array(buffer)
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i])
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
   }
   return btoa(binary)
 }
 
 function contentType(filename: string): string {
   const ext = filename.split('.').pop() ?? ''
-  return contentTypes[ext] || 'image/png'
+  return contentTypes[ext] ?? 'image/png'
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -63,11 +63,15 @@ export function formatFileSize(bytes: number): string {
   if (bytes === 0) return '0 b'
   const i = Math.floor(Math.log2(bytes) / 10)
   if (i === 0) return bytes.toLocaleString('en-US') + ' b'
+  const size = sizes[i]
+  if (size === undefined) {
+    throw new Error(`Size not found at index ${i}`)
+  }
   const base = bytes / Math.pow(1024, i)
   return (
     (base < 10 ? base.toFixed(1) : Math.round(base)).toLocaleString('en-US') +
     ' ' +
-    sizes[i]
+    size
   )
 }
 

--- a/src/lib/workers/parquetWorker.ts
+++ b/src/lib/workers/parquetWorker.ts
@@ -38,7 +38,7 @@ self.onmessage = async ({ data }: {
         throw new Error('sortIndex requires all rows')
       const sortColumn = await parquetQuery({ metadata, file, columns: [orderBy], compressors })
       const indices = Array.from(sortColumn, (_, index) => index).sort((a, b) =>
-        compare<unknown>(sortColumn[a][orderBy], sortColumn[b][orderBy])
+        compare<unknown>(sortColumn[a]?.[orderBy], sortColumn[b]?.[orderBy])
       )
       postIndicesMessage({ indices, queryId })
     } catch (error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
 
     "rootDir": "src",
     "outDir": "lib",


### PR DESCRIPTION
Because i could be out of bounds (or even: not an integer).

This rule is sometimes really annoying (some call it pedantic), but I think it can help find bugs.

I'm enabling it as a distinct PR, before a bigger PR (#180) where I upgrade hightable, and need to add code to sort the rows along multiple columns, where I prefer to have this rule enabled, as in hightable.