### PR TITLE
export built hyperparam CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.es.min.js",
       "require": "./lib/index.umd.min.js"
-    }
+    },
+    "./hyperparam.css": "./lib/hyperparam.css"
   },
   "bin": {
     "hyp": "bin/cli.js",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "watch:url": "NODE_ENV=development nodemon bin/cli.js https://hyperparam.blob.core.windows.net/hyperparam/starcoderdata-js-00000-of-00065.parquet"
   },
   "dependencies": {
-    "hightable": "0.13.1",
+    "hightable": "0.13.2",
     "hyparquet": "1.10.1",
     "hyparquet-compressors": "1.1.1",
     "icebird": "0.1.9",

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,10 +1,9 @@
 import { Source } from '../lib/sources/types.js'
-import { BreadcrumbConfig } from './Breadcrumb.js'
 import Cell from './Cell.js'
 import File, { FileConfig } from './File.js'
 import Folder from './Folder.js'
 
-export type PageConfig = FileConfig & BreadcrumbConfig
+export type PageConfig = FileConfig
 export interface Navigation {
   col?: number
   row?: number

--- a/src/components/viewers/ParquetView.tsx
+++ b/src/components/viewers/ParquetView.tsx
@@ -1,16 +1,22 @@
-import HighTable, { DataFrame, rowCache, stringify } from 'hightable'
+import HighTable, { DataFrame, rowCache } from 'hightable'
 import { asyncBufferFromUrl, parquetMetadataAsync } from 'hyparquet'
 import React, { useCallback, useEffect, useState } from 'react'
 import { RoutesConfig, appendSearchParams } from '../../lib/routes.js'
 import { FileSource } from '../../lib/sources/types.js'
 import { parquetDataFrame } from '../../lib/tableProvider.js'
+import { cn } from '../../lib/utils.js'
 import styles from '../../styles/ParquetView.module.css'
 import { Spinner } from '../Layout.js'
 import CellPanel from './CellPanel.js'
 import ContentHeader, { ContentSize } from './ContentHeader.js'
 import SlidePanel, { SlidePanelConfig } from './SlidePanel.js'
 
-export type ParquetViewConfig = SlidePanelConfig & RoutesConfig
+interface HighTableConfig {
+  hightable?: {
+    className?: string;
+  }
+}
+export type ParquetViewConfig = SlidePanelConfig & RoutesConfig & HighTableConfig
 
 interface ViewerProps {
   source: FileSource
@@ -102,8 +108,7 @@ export default function ParquetView({ source, setProgress, setError, config }: V
       onDoubleClickCell={onDoubleClickCell}
       onMouseDownCell={onMouseDownCell}
       onError={setError}
-      className={styles.hightable}
-      stringify={stringify}
+      className={cn(styles.hightable, config?.hightable?.className)}
     />}
 
     {isLoading && <div className='center'><Spinner /></div>}


### PR DESCRIPTION
- export the build CSS as `'hyperparam/hyperparam.css'`
- let pass a custom CSS class to hightable in `Page`'s `config` prop as `{hightable: {className: ...}}`
- upgrade hightable