### PR TITLE
update dependencies (fix bugs in hightable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,17 +50,17 @@
     "watch:url": "NODE_ENV=development nodemon bin/cli.js https://hyperparam.blob.core.windows.net/hyperparam/starcoderdata-js-00000-of-00065.parquet"
   },
   "dependencies": {
-    "hightable": "0.13.3",
+    "hightable": "0.13.4",
     "hyparquet": "1.10.2",
     "hyparquet-compressors": "1.1.1",
-    "icebird": "0.1.12",
+    "icebird": "0.1.13",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@eslint/js": "9.23.0",
-    "@testing-library/react": "16.2.0",
-    "@types/node": "22.13.15",
+    "@testing-library/react": "16.3.0",
+    "@types/node": "22.14.0",
     "@types/react": "19.0.12",
     "@types/react-dom": "19.0.4",
     "@vitejs/plugin-react": "4.3.4",


### PR DESCRIPTION
Requires https://github.com/hyparam/hightable/pull/97 before (tests are failing meanwhile because 0.13.4 has not been published yet).