### PR TITLE
reject at least one promise when fetching a row group fails

### DIFF
--- a/src/lib/tableProvider.ts
+++ b/src/lib/tableProvider.ts
@@ -75,7 +75,11 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
           }
         })
         .catch((error: unknown) => {
-          console.error('Error fetching row group', error)
+          const prefix = `Error fetching row group ${groupIndex} (${rowStart}-${rowEnd}).`
+          console.error(prefix, error)
+          const reason = `${prefix} ${error}`
+          // reject the index of the first row (it's enough to trigger the error bar)
+          data[rowStart]?.index.reject(reason)
         })
       groups[groupIndex] = true
     }


### PR DESCRIPTION
See https://github.com/hyparam/hyperparam-cli/issues/205

The error bar was not shown when fetching a row group failed. Now it appears:

![Screenshot From 2025-04-07 16-45-01](https://github.com/user-attachments/assets/6fd76fa3-e142-4541-afc6-e2d3dc019654)
