### PR TITLE
Export more components

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/node": "22.14.1",
     "@types/react": "19.1.2",
     "@types/react-dom": "19.1.2",
-    "@vitejs/plugin-react": "4.3.4",
+    "@vitejs/plugin-react": "4.4.1",
     "@vitest/coverage-v8": "3.1.2",
     "eslint": "9.25.1",
     "eslint-plugin-react": "7.37.5",

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -8,7 +8,7 @@ export interface Navigation {
   row?: number
 }
 
-interface PageProps {
+export interface PageProps {
   source: Source,
   navigation?: Navigation,
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,18 +1,51 @@
+import AvroView from './AvroView/AvroView.js'
 import Breadcrumb from './Breadcrumb/Breadcrumb.js'
 import Cell from './Cell/Cell.js'
+import CellPanel from './CellPanel/CellPanel.js'
 import ContentWrapper from './ContentWrapper/ContentWrapper.js'
 import Dropdown from './Dropdown/Dropdown.js'
 import ErrorBar from './ErrorBar/ErrorBar.js'
 import File from './File/File.js'
 import Folder from './Folder/Folder.js'
 import ImageView from './ImageView/ImageView.js'
+import Json from './Json/Json.js'
+import JsonView from './JsonView/JsonView.js'
 import Layout from './Layout/Layout.js'
 import Markdown from './Markdown/Markdown.js'
 import MarkdownView from './MarkdownView/MarkdownView.js'
 import Page from './Page/Page.js'
 import ParquetView from './ParquetView/ParquetView.js'
+import ProgressBar from './ProgressBar/ProgressBar.js'
 import SlidePanel from './SlidePanel/SlidePanel.js'
 import Spinner from './Spinner/Spinner.js'
 import TextView from './TextView/TextView.js'
 import Viewer from './Viewer/Viewer.js'
-export { Breadcrumb, Cell, ContentWrapper, Dropdown, ErrorBar, File, Folder, ImageView, Layout, Markdown, MarkdownView, Page, ParquetView, SlidePanel, Spinner, TextView, Viewer }
+import VisuallyHidden from './VisuallyHidden/VisuallyHidden.js'
+import Welcome from './Welcome/Welcome.js'
+
+export {
+  AvroView,
+  Breadcrumb,
+  Cell,
+  CellPanel,
+  ContentWrapper,
+  Dropdown,
+  ErrorBar,
+  File,
+  Folder,
+  ImageView,
+  Json,
+  JsonView,
+  Layout,
+  Markdown,
+  MarkdownView,
+  Page,
+  ParquetView,
+  ProgressBar,
+  SlidePanel,
+  Spinner,
+  TextView,
+  Viewer,
+  VisuallyHidden,
+  Welcome,
+}

--- a/src/lib/tableProvider.ts
+++ b/src/lib/tableProvider.ts
@@ -51,6 +51,7 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
       // Initialize with resolvable promises
       for (let i = rowStart; i < rowEnd; i++) {
         data[i] = resolvableRow(header)
+        data[i]?.index.resolve(i)
       }
       parquetQueryWorker({ from, metadata, rowStart, rowEnd })
         .then((groupData) => {
@@ -59,7 +60,6 @@ export function parquetDataFrame(from: AsyncBufferFrom, metadata: FileMetaData):
             if (dataRow === undefined) {
               throw new Error(`Missing data row for index ${i}`)
             }
-            dataRow.index.resolve(i)
             const j = i - rowStart
             const row = groupData[j]
             if (row === undefined) {


### PR DESCRIPTION
Exporting more components makes it easier to hack on the demos etc.

Also resolve rowgroup indexes a little sooner.