### PR TITLE
Add Versions component in Breadcrumb

### DIFF
--- a/.storybook/global.css
+++ b/.storybook/global.css
@@ -85,8 +85,3 @@ h6 {
 .custom-versions div a {
   text-decoration: underline;
 }
-
-.custom-search {
-  margin-left: auto;
-  margin-right: 20px;
-}

--- a/.storybook/global.css
+++ b/.storybook/global.css
@@ -81,3 +81,12 @@ h6 {
 * {
   font-family: "Mulish", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
+
+.custom-versions div a {
+  text-decoration: underline;
+}
+
+.custom-search {
+  margin-left: auto;
+  margin-right: 20px;
+}

--- a/src/components/Breadcrumb/Breadcrumb.module.css
+++ b/src/components/Breadcrumb/Breadcrumb.module.css
@@ -4,7 +4,8 @@
   display: flex;
   font-size: 18px;
   height: 32px;
-  justify-content: space-between;
+  justify-content: start;
+  gap: 10px;
   min-height: 32px;
   padding-left: 20px;
   padding-right: 10px;

--- a/src/components/Breadcrumb/Breadcrumb.module.css
+++ b/src/components/Breadcrumb/Breadcrumb.module.css
@@ -4,7 +4,7 @@
   display: flex;
   font-size: 18px;
   height: 32px;
-  justify-content: start;
+  justify-content: space-between;
   gap: 10px;
   min-height: 32px;
   padding-left: 20px;
@@ -45,5 +45,13 @@
     & a:not(:last-child) {
       display: none;
     }
+  }
+}
+
+.versions {
+  margin-left: auto;
+
+  [aria-current] {
+    font-weight: bold;
   }
 }

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ConfigProvider } from '../../hooks/useConfig.js'
+import Breadcrumb from './Breadcrumb.js'
+
+const meta: Meta<typeof Breadcrumb> = {
+  component: Breadcrumb,
+}
+export default meta
+type Story = StoryObj<typeof Breadcrumb>;
+export const Default: Story = {
+  args: {
+    source: {
+      kind: 'file',
+      sourceId: '/part1/part2/file.txt',
+      fileName: 'file.txt',
+      resolveUrl: '/part1/part2/file.txt',
+      sourceParts: [
+        { text: '/', sourceId: '/' },
+        { text: 'part1/', sourceId: '/part1/' },
+        { text: 'part2/', sourceId: '/part1/part2/' },
+      ],
+      versions: {
+        label: 'Versions',
+        versions: [
+          { label: 'v1.0', sourceId: 'part1/part2/file.txt?version=v1.0' },
+          { label: 'v2.0', sourceId: 'part1/part2/file.txt?version=v2.0' },
+        ],
+      },
+    },
+  },
+  render: (args) => {
+    const config = {
+      routes: {
+        getSourceRouteUrl: ({ sourceId }: { sourceId: string }) => `/files?key=${sourceId}`,
+      },
+      customClass: {
+        versions: 'custom-versions',
+      },
+    }
+    return (
+      <ConfigProvider value={config}>
+        <Breadcrumb {...args}>
+          <div className="custom-search">SEARCH</div>
+        </Breadcrumb>
+      </ConfigProvider>
+    )
+  },
+}

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -20,10 +20,11 @@ export const Default: Story = {
         { text: 'part2/', sourceId: '/part1/part2/' },
       ],
       versions: {
-        label: 'Versions',
+        label: 'Branches',
         versions: [
-          { label: 'v1.0', sourceId: 'part1/part2/file.txt?version=v1.0' },
-          { label: 'v2.0', sourceId: 'part1/part2/file.txt?version=v2.0' },
+          { label: 'master', sourceId: '/part1/part2/file.txt' },
+          { label: 'dev', sourceId: '/part1/part2/file.txt?branch=dev' },
+          { label: 'refs/convert/parquet', sourceId: '/part1/part2/file.txt?branch=refs/convert/parquet' },
         ],
       },
     },
@@ -40,7 +41,7 @@ export const Default: Story = {
     return (
       <ConfigProvider value={config}>
         <Breadcrumb {...args}>
-          <div className="custom-search">SEARCH</div>
+          <input type='text' placeholder="Search..." />
         </Breadcrumb>
       </ConfigProvider>
     )

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -27,4 +27,31 @@ describe('Breadcrumb Component', () => {
     const subdir2Link = getByText('subdir2/')
     expect(subdir2Link.closest('a')?.getAttribute('href')).toBe('/files?key=subdir1/subdir2/')
   })
+
+  it('handles versions correctly', () => {
+    const source = getHyperparamSource('subdir1/subdir2/', { endpoint })
+    assert(source !== undefined)
+    source.versions = {
+      label: 'Versions',
+      versions: [
+        { label: 'v1.0', sourceId: 'v1.0' },
+        { label: 'v2.0', sourceId: 'v2.0' },
+      ],
+    }
+
+    const config: Config = {
+      routes: {
+        getSourceRouteUrl: ({ sourceId }) => `/files?key=${sourceId}`,
+      },
+    }
+    const { getByText, getAllByRole } = render(<ConfigProvider value={config}>
+      <Breadcrumb source={source} />
+    </ConfigProvider>)
+
+    const versionsLabel = getByText('Versions')
+    expect(versionsLabel).toBeDefined()
+    const versionLinks = getAllByRole('menuitem')
+    expect(versionLinks.length).toBe(2)
+    expect(versionLinks[0]?.getAttribute('href')).toBe('/files?key=v1.0')
+  })
 })

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,12 +1,24 @@
 import type { ReactNode } from 'react'
 import { useConfig } from '../../hooks/useConfig.js'
 import type { Source } from '../../lib/sources/types.js'
+import { Version } from '../../lib/sources/types.js'
 import { cn } from '../../lib/utils.js'
+import Dropdown from '../Dropdown/Dropdown.js'
 import styles from './Breadcrumb.module.css'
 
 interface BreadcrumbProps {
   source: Source,
   children?: ReactNode
+}
+
+function Versions({ versions, label }: { versions: Version[], label: string }) {
+  const { routes, customClass } = useConfig()
+
+  return <Dropdown label={label} className={customClass?.versions}>
+    {versions.map(({ label, sourceId }) => {
+      return <a key={sourceId} role="menuitem" href={routes?.getSourceRouteUrl?.({ sourceId })}>{label}</a>
+    })}
+  </Dropdown>
 }
 
 /**
@@ -21,6 +33,7 @@ export default function Breadcrumb({ source, children }: BreadcrumbProps) {
         <a href={routes?.getSourceRouteUrl?.({ sourceId: part.sourceId }) ?? ''} key={depth}>{part.text}</a>
       )}
     </div>
+    {source.versions && <Versions label={source.versions.label} versions={source.versions.versions} />}
     {children}
   </nav>
 }

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react'
 import { useConfig } from '../../hooks/useConfig.js'
 import type { Source } from '../../lib/sources/types.js'
-import { Version } from '../../lib/sources/types.js'
 import { cn } from '../../lib/utils.js'
 import Dropdown from '../Dropdown/Dropdown.js'
 import styles from './Breadcrumb.module.css'
@@ -11,12 +10,20 @@ interface BreadcrumbProps {
   children?: ReactNode
 }
 
-function Versions({ versions, label }: { versions: Version[], label: string }) {
+function Versions({ source }: { source: Source }) {
   const { routes, customClass } = useConfig()
 
-  return <Dropdown label={label} className={customClass?.versions}>
+  if (!source.versions) return null
+  const { label, versions } = source.versions
+
+  return <Dropdown label={label} className={cn(styles.versions, customClass?.versions)} align="right">
     {versions.map(({ label, sourceId }) => {
-      return <a key={sourceId} role="menuitem" href={routes?.getSourceRouteUrl?.({ sourceId })}>{label}</a>
+      return <a
+        key={sourceId}
+        role="menuitem"
+        href={routes?.getSourceRouteUrl?.({ sourceId })}
+        aria-current={sourceId === source.sourceId ? 'true' : undefined}
+      >{label}</a>
     })}
   </Dropdown>
 }
@@ -33,7 +40,7 @@ export default function Breadcrumb({ source, children }: BreadcrumbProps) {
         <a href={routes?.getSourceRouteUrl?.({ sourceId: part.sourceId }) ?? ''} key={depth}>{part.text}</a>
       )}
     </div>
-    {source.versions && <Versions label={source.versions.label} versions={source.versions.versions} />}
+    {source.versions && <Versions source={source} />}
     {children}
   </nav>
 }

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -27,6 +27,7 @@ export interface Config {
     slidePanel?: string
     spinner?: string
     textView?: string
+    versions?: string
     welcome?: string
   }
   routes?: {

--- a/src/lib/sources/types.ts
+++ b/src/lib/sources/types.ts
@@ -14,9 +14,20 @@ export interface SourcePart {
   sourceId: string
 }
 
+export interface Version {
+  label: string
+  sourceId: string
+}
+
+export interface VersionsData {
+  label: string // "version" or "branch"
+  versions: Version[]
+}
+
 interface BaseSource {
   sourceId: string
   sourceParts: SourcePart[]
+  versions?: VersionsData
 }
 
 export interface FileSource extends BaseSource {


### PR DESCRIPTION
Can be used for iceberg versions, or git branches, for example.

See https://github.com/hyparam/space/issues/3

![Screenshot From 2025-04-22 23-40-41](https://github.com/user-attachments/assets/314f8479-1072-473e-b378-45336a6a86f8)
