### PR TITLE
Virtual row groups of size 1000

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,7 @@ export default typescript.config(
       eqeqeq: 'error',
       'func-style': ['error', 'declaration'],
       indent: ['error', 2, { SwitchCase: 1 }],
+      'key-spacing': 'error',
       'no-constant-condition': 'off',
       'no-extra-parens': 'error',
       'no-multi-spaces': 'error',


### PR DESCRIPTION
This PR changes the `parquetDataFrame` function. This function would fetch and decode by row group. This made sense since we basically need to download the whole rowgroup anyway.

The problem is that for files with very large row groups, even after downloading, decoding all that data can lag the browser and eat up memory. See https://github.com/hyparam/demos/issues/22#issuecomment-2877254286

This PR changes `parquetDataFrame` to use _virtual_ row groups which are max size 1000. Also splits virtual row groups at the natural row group boundaries to avoid fetching two natual row groups at once.

Fixes https://github.com/hyparam/demos/issues/22

Previously the parquet file referenced in that issue would take about 15 seconds to load and use 6.5gb of memory on chrome. After the change it loads in 1-2 sec with 545mb memory! :tada: 