### PR TITLE
Markdown: handle unicode list markers

### DIFF
--- a/src/components/Markdown/Markdown.test.tsx
+++ b/src/components/Markdown/Markdown.test.tsx
@@ -239,6 +239,22 @@ describe('Markdown lists', () => {
     expect(codeBlock).toBeDefined()
     expect(codeBlock?.textContent).toContain('console.log("Nested code")')
   })
+
+  it('renders a list with unicode dash –', () => {
+    const text = '– Item 1\n– Item 2\n– Item 3\n\n'
+    const { getByText } = render(<Markdown text={text} />)
+    expect(getByText('Item 1')).toBeDefined()
+    expect(getByText('Item 2')).toBeDefined()
+    expect(getByText('Item 3')).toBeDefined()
+  })
+
+  it('renders a list with unicode dot •', () => {
+    const text = '• Item 1\n• Item 2\n• Item 3\n\n'
+    const { getByText } = render(<Markdown text={text} />)
+    expect(getByText('Item 1')).toBeDefined()
+    expect(getByText('Item 2')).toBeDefined()
+    expect(getByText('Item 3')).toBeDefined()
+  })
 })
 
 describe('Markdown with nested elements', () => {

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -67,7 +67,7 @@ function parseMarkdown(text: string): Token[] {
     }
 
     // List (ordered or unordered)
-    const listMatch = /^(\s*)([-*+]|\d+\.)\s+(.*)/.exec(line)
+    const listMatch = /^(\s*)([-*+–•‣◦○⚬]|\d+\.)\s+(.*)/.exec(line)
     if (listMatch !== null) {
       if (!(1 in listMatch) || !(2 in listMatch)) {
         throw new Error('Missing entries in regex matches')
@@ -109,7 +109,7 @@ function parseMarkdown(text: string): Token[] {
       if (ln.startsWith('```')) break // code block
       if (ln.startsWith('>')) break // blockquote
       if (/^(#{1,6})\s+/.test(ln)) break // heading
-      if (/^(\s*)([-*+]|\d+\.)\s+/.test(ln)) break // list item
+      if (/^(\s*)([-*+–•‣◦○⚬]|\d+\.)\s+/.test(ln)) break // list item
 
       paraLines.push(ln)
       i++
@@ -137,7 +137,7 @@ function parseList(lines: string[], start: number, baseIndent: number): [Token[]
     }
 
     // This matches a new top-level bullet/number for the list
-    const match = /^(\s*)([-*+]|\d+\.)\s+(.*)/.exec(line)
+    const match = /^(\s*)([-*+–•‣◦○⚬]|\d+\.)\s+(.*)/.exec(line)
     // If we don't find a bullet/number at the same indent, break out
     if (match === null || !(1 in match) || match[1].length !== baseIndent || !(3 in match)) {
       break
@@ -186,7 +186,7 @@ function parseList(lines: string[], start: number, baseIndent: number): [Token[]
         }
 
         // Check for nested list
-        const sublistMatch = /^(\s*)([-*+]|\d+\.)\s+(.*)/.exec(subline)
+        const sublistMatch = /^(\s*)([-*+–•‣◦○⚬]|\d+\.)\s+(.*)/.exec(subline)
         if (sublistMatch && 1 in sublistMatch && sublistMatch[1].length > baseIndent && 2 in sublistMatch) {
           const newBaseIndent = sublistMatch[1].length
           const ordered = /^\d+\./.test(sublistMatch[2])


### PR DESCRIPTION
Sometimes models output literal unicode which even github doesn't parse as lists, stuff like:

```
• glaiveai/reasoning-v1-20m  
  – 22 M synthetic Q-A pairs with model-generated reasoning in the “response” field (Apache-2.0).  
```