### PR TITLE
Markdown: newline adds a break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   push:
-    branches: ["master"]
   pull_request:
 jobs:
   lint:

--- a/src/components/Markdown/Markdown.test.tsx
+++ b/src/components/Markdown/Markdown.test.tsx
@@ -103,6 +103,14 @@ describe('Markdown', () => {
     const { getByText } = render(<Markdown text={text} />)
     expect(getByText('This is a blockquote.')).toBeDefined()
   })
+
+  it('soft line break creates a break tag', () => {
+    // Models often expect newlines to be presented as line breaks
+    const text = 'Line one\nLine two'
+    const { container } = render(<Markdown text={text} />)
+    expect(container.innerHTML).toContain('Line one<br>Line two')
+    expect(container.querySelector('br')).toBeDefined()
+  })
 })
 
 describe('Markdown horizontal rules', () => {


### PR DESCRIPTION
Models often expect newlines to be presented as line breaks

This isn't exactly official markdown? But thats not really what matters. Github agrees.

Left a flag `softLineBreaks` in case we change our mind.
