### PR TITLE
Markdown: fix child key warning

### DIFF
--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -641,7 +641,7 @@ function renderTokens(tokens: Token[], keyPrefix = ''): ReactNode[] {
           )
         )
 
-        return createElement('table', { key }, [thead, tbody])
+        return createElement('table', { key }, thead, tbody)
       }
       default:
         return null


### PR DESCRIPTION
Fix react warning:

```
Warning: Each child in a list should have a unique "key" prop.
```