### PR TITLE
Add support for react19

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,7 @@
     "hightable": "0.19.5",
     "hyparquet": "1.18.0",
     "hyparquet-compressors": "1.1.1",
-    "icebird": "0.3.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "icebird": "0.3.0"
   },
   "devDependencies": {
     "@eslint/js": "9.35.0",
@@ -80,11 +78,17 @@
     "jsdom": "27.0.0",
     "nodemon": "3.1.10",
     "npm-run-all": "4.1.5",
+    "react": "19.1.1",
+    "react-dom": "19.1.1",
     "storybook": "9.1.6",
     "typescript": "5.8.3",
     "typescript-eslint": "8.44.0",
     "vite": "7.1.5",
     "vitest": "3.2.4"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1 || ^19",
+    "react-dom": "^18.3.1 || ^19"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "watch:url": "NODE_ENV=development nodemon bin/cli.js https://hyperparam.blob.core.windows.net/hyperparam/starcoderdata-js-00000-of-00065.parquet"
   },
   "dependencies": {
-    "hightable": "0.19.4",
+    "hightable": "0.19.5",
     "hyparquet": "1.18.0",
     "hyparquet-compressors": "1.1.1",
     "icebird": "0.3.0",
@@ -69,7 +69,7 @@
     "@types/node": "24.5.1",
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
-    "@vitejs/plugin-react": "5.0.2",
+    "@vitejs/plugin-react": "5.0.3",
     "@vitest/coverage-v8": "3.2.4",
     "eslint": "9.35.0",
     "eslint-plugin-react": "7.37.5",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
-// https://vite.dev/config/
+// https://vite.dev/config/ and
+// https://vitest.dev/config/#configuring-vitest
 export default defineConfig({
   plugins: [react()],
   build: {


### PR DESCRIPTION
Also:

- upgrade dependencies
- fix a type error in vite's config

---

I verified that `hyperparam` can be used as a dependency in a project with React 18 or with React 19 (in demos/hyparquet).